### PR TITLE
Server: tighten game state machine, reconnection, graceful shutdown, monitor auth

### DIFF
--- a/server/.env.development
+++ b/server/.env.development
@@ -1,1 +1,2 @@
 SAMPLE=development
+MONITOR_PASSWORD=dev

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -11,6 +11,7 @@
         "@colyseus/tools": "^0.17.19",
         "colyseus": "^0.17.10",
         "express": "^5.2.1",
+        "express-basic-auth": "^1.2.1",
       },
       "devDependencies": {
         "@colyseus/loadtest": "^0.17.8",
@@ -245,6 +246,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
+
     "blessed": ["blessed@0.1.81", "", { "bin": { "blessed": "./bin/tput.js" } }, "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ=="],
 
     "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
@@ -360,6 +363,8 @@
     "eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-basic-auth": ["express-basic-auth@1.2.1", "", { "dependencies": { "basic-auth": "^2.0.1" } }, "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA=="],
 
     "express-jwt": ["express-jwt@8.5.1", "", { "dependencies": { "@types/jsonwebtoken": "^9", "express-unless": "^2.1.3", "jsonwebtoken": "^9.0.0" } }, "sha512-Dv6QjDLpR2jmdb8M6XQXiCcpEom7mK8TOqnr0/TngDKsG2DHVkO8+XnVxkJVN7BuS1I3OrGw6N8j5DaaGgkDRQ=="],
 
@@ -621,7 +626,7 @@
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -747,9 +752,13 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "express-session/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
     "express-session/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "express-session/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -757,7 +766,15 @@
 
     "jsonwebtoken/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
 
+    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "jwk-to-pem/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "mocha/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "@colyseus/playground": "^0.17.12",
     "@colyseus/tools": "^0.17.19",
     "colyseus": "^0.17.10",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-basic-auth": "^1.2.1"
   }
 }

--- a/server/src/app.config.ts
+++ b/server/src/app.config.ts
@@ -1,63 +1,60 @@
 import config from "@colyseus/tools";
 import { monitor } from "@colyseus/monitor";
 import { playground } from "@colyseus/playground";
+import basicAuth from "express-basic-auth";
 
-/**
- * Import your Room files
- */
 import { MyRoom } from "./rooms/MyRoom";
+
+const ROOMS = [
+  "en",
+  "zh",
+  "es",
+  "fr",
+  "ar",
+  "ru",
+  "pt",
+  "id",
+  "de",
+  "ja",
+  "ko",
+];
 
 export default config({
   initializeGameServer: (gameServer) => {
-    /**
-     * Define your room handlers:
-     */
-    const rooms = [
-      "en",
-      "zh",
-      "es",
-      "fr",
-      "ar",
-      "ru",
-      "pt",
-      "id",
-      "de",
-      "ja",
-      "ko",
-    ];
-    for (const room of rooms) {
+    for (const room of ROOMS) {
       gameServer.define(room, MyRoom, { lang: room });
     }
   },
 
   initializeExpress: (app) => {
-    /**
-     * Bind your custom express routes here:
-     * Read more: https://expressjs.com/en/starter/basic-routing.html
-     */
-    app.get("/hello_world", (req, res) => {
+    app.get("/hello_world", (_req, res) => {
       res.send("It's time to kick ass and chew bubblegum!");
     });
 
-    /**
-     * Use @colyseus/playground
-     * (It is not recommended to expose this route in a production environment)
-     */
     if (process.env.NODE_ENV !== "production") {
       app.use("/", playground);
     }
 
-    /**
-     * Use @colyseus/monitor
-     * It is recommended to protect this route with a password
-     * Read more: https://docs.colyseus.io/tools/monitor/#restrict-access-to-the-panel-using-a-password
-     */
-    app.use("/colyseus", monitor());
+    // Mount the colyseus monitor only if a password is set. The monitor
+    // exposes room state and lets the operator kick clients, so leaving it
+    // open is unsafe — fail closed instead.
+    const monitorPassword = process.env.MONITOR_PASSWORD;
+    if (monitorPassword) {
+      const monitorUser = process.env.MONITOR_USERNAME ?? "admin";
+      app.use(
+        "/colyseus",
+        basicAuth({
+          users: { [monitorUser]: monitorPassword },
+          challenge: true,
+        }),
+        monitor(),
+      );
+    } else {
+      console.warn(
+        "MONITOR_PASSWORD not set — /colyseus monitor route is disabled",
+      );
+    }
   },
 
-  beforeListen: () => {
-    /**
-     * Before before gameServer.listen() is called.
-     */
-  },
+  beforeListen: () => {},
 });

--- a/server/src/rooms/MyRoom.ts
+++ b/server/src/rooms/MyRoom.ts
@@ -19,15 +19,15 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
       });
     });
 
-    this.onMessage("start", (client) => {
+    this.onMessage("start", async (client) => {
       const player = this.state.players.get(client.sessionId);
       if (!player || player.status !== "idle") return;
       player.status = "playing";
       // Lock once anyone has started so new joiners can't slip into a live game.
-      if (!this.locked) this.lock();
+      if (!this.locked) await this.lock();
     });
 
-    this.onMessage("end", (client) => {
+    this.onMessage("end", async (client) => {
       const player = this.state.players.get(client.sessionId);
       if (!player || player.status !== "playing") return;
       player.status = "done";
@@ -35,7 +35,7 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
         id: client.sessionId,
         solved: player.solved,
       });
-      this.maybeReset();
+      await this.maybeReset();
     });
   }
 
@@ -48,7 +48,7 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
   async onLeave(client: Client, code?: number) {
     console.log(client.sessionId, "left!", "code=", code);
     if (code === CloseCode.CONSENTED) {
-      this.removePlayer(client.sessionId);
+      await this.removePlayer(client.sessionId);
       return;
     }
     try {
@@ -63,7 +63,7 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
       }
     } catch (e) {
       console.error("RECONNECT FAILED", client.sessionId, e);
-      this.removePlayer(client.sessionId);
+      await this.removePlayer(client.sessionId);
     }
   }
 
@@ -77,18 +77,18 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
     console.log("room", this.roomId, "disposing...");
   }
 
-  private removePlayer(sessionId: string) {
+  private async removePlayer(sessionId: string) {
     if (!this.state.players.has(sessionId)) return;
     this.state.players.delete(sessionId);
     this.broadcast("players", [...this.state.players.keys()]);
-    this.maybeReset();
+    await this.maybeReset();
   }
 
   // Reopen the room once no players are mid-game; reset everyone's status
   // so the next round starts cleanly.
-  private maybeReset() {
+  private async maybeReset() {
     if (this.state.players.size === 0) {
-      if (this.locked) this.unlock();
+      if (this.locked) await this.unlock();
       return;
     }
     const stillPlaying = [...this.state.players.values()].some(
@@ -99,6 +99,6 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
       p.status = "idle";
       p.solved = 0;
     });
-    if (this.locked) this.unlock();
+    if (this.locked) await this.unlock();
   }
 }

--- a/server/src/rooms/MyRoom.ts
+++ b/server/src/rooms/MyRoom.ts
@@ -1,31 +1,41 @@
 import { Room, Client, CloseCode } from "@colyseus/core";
 import { MyRoomState, Player } from "./schema/MyRoomState";
 
+const RECONNECTION_SECONDS = 60;
+
 export class MyRoom extends Room<{ state: MyRoomState }> {
   maxClients = 4;
 
   onCreate(_options: { lang: string }) {
-    this.setState(new MyRoomState());
+    this.state = new MyRoomState();
+
     this.onMessage("solve", (client) => {
       const player = this.state.players.get(client.sessionId);
+      if (!player || player.status !== "playing") return;
       player.solved++;
       this.broadcast("update", {
         id: client.sessionId,
         solved: player.solved,
       });
     });
-    this.onMessage("start", () => {
-      this.lock();
+
+    this.onMessage("start", (client) => {
+      const player = this.state.players.get(client.sessionId);
+      if (!player || player.status !== "idle") return;
+      player.status = "playing";
+      // Lock once anyone has started so new joiners can't slip into a live game.
+      if (!this.locked) this.lock();
     });
+
     this.onMessage("end", (client) => {
       const player = this.state.players.get(client.sessionId);
+      if (!player || player.status !== "playing") return;
+      player.status = "done";
       this.broadcast("final", {
         id: client.sessionId,
         solved: player.solved,
       });
-    });
-    this.onMessage("unlock", () => {
-      this.unlock();
+      this.maybeReset();
     });
   }
 
@@ -36,31 +46,59 @@ export class MyRoom extends Room<{ state: MyRoomState }> {
   }
 
   async onLeave(client: Client, code?: number) {
-    console.log(client.sessionId, "left!");
-    try {
-      if (code === CloseCode.CONSENTED) {
-        throw new Error("consented leave");
-      }
-      // allow disconnected client to reconnect into this room
-      await this.allowReconnection(client, 2.5); // sync with client timeout
-      // client returned! broadcast changes.
-      console.log(client.sessionId, "reconnected!");
-      this.broadcast("update", {
-        id: client.sessionId,
-        solved: this.state.players.get(client.sessionId).solved,
-      }); // update player score on clients
-    } catch {
-      // disconnect not recovered
-    } finally {
-      this.state.players.delete(client.sessionId);
-      this.broadcast(
-        "players",
-        [...this.state.players.keys()].filter((id) => id !== client.sessionId),
-      ); // refresh players state on clients
+    console.log(client.sessionId, "left!", "code=", code);
+    if (code === CloseCode.CONSENTED) {
+      this.removePlayer(client.sessionId);
+      return;
     }
+    try {
+      await this.allowReconnection(client, RECONNECTION_SECONDS);
+      console.log(client.sessionId, "reconnected!");
+      const player = this.state.players.get(client.sessionId);
+      if (player) {
+        this.broadcast("update", {
+          id: client.sessionId,
+          solved: player.solved,
+        });
+      }
+    } catch (e) {
+      console.error("RECONNECT FAILED", client.sessionId, e);
+      this.removePlayer(client.sessionId);
+    }
+  }
+
+  async onBeforeShutdown() {
+    console.log("room", this.roomId, "shutting down — notifying clients");
+    this.broadcast("shutdown");
+    await this.disconnect();
   }
 
   onDispose() {
     console.log("room", this.roomId, "disposing...");
+  }
+
+  private removePlayer(sessionId: string) {
+    if (!this.state.players.has(sessionId)) return;
+    this.state.players.delete(sessionId);
+    this.broadcast("players", [...this.state.players.keys()]);
+    this.maybeReset();
+  }
+
+  // Reopen the room once no players are mid-game; reset everyone's status
+  // so the next round starts cleanly.
+  private maybeReset() {
+    if (this.state.players.size === 0) {
+      if (this.locked) this.unlock();
+      return;
+    }
+    const stillPlaying = [...this.state.players.values()].some(
+      (p) => p.status === "playing",
+    );
+    if (stillPlaying) return;
+    this.state.players.forEach((p) => {
+      p.status = "idle";
+      p.solved = 0;
+    });
+    if (this.locked) this.unlock();
   }
 }

--- a/server/src/rooms/schema/MyRoomState.ts
+++ b/server/src/rooms/schema/MyRoomState.ts
@@ -1,7 +1,10 @@
 import { Schema, MapSchema, type } from "@colyseus/schema";
 
+export type PlayerStatus = "idle" | "playing" | "done";
+
 export class Player extends Schema {
   @type("number") solved: number = 0;
+  @type("string") status: PlayerStatus = "idle";
 }
 
 export class MyRoomState extends Schema {


### PR DESCRIPTION
## Summary

Server-side correctness and reliability pass. No client changes (existing client keeps working — its now-redundant `unlock` message is silently ignored by the server).

### Game state machine
Server no longer trusts arbitrary message ordering from clients.

- Add `Player.status: "idle" | "playing" | "done"` to schema
- `solve` is rejected unless the sender is `playing`
- `start` is rejected unless the sender is `idle`; first `start` locks the room
- `end` is rejected unless the sender is `playing`
- Removed the `unlock` message handler. Server now manages locking via a private `maybeReset` that runs after `end` and after `onLeave` — when no players are mid-game, statuses reset to idle and the room unlocks for the next round.

### Reconnection
- `onLeave` previously deleted the player inside `finally`, wiping them out even after a successful reconnect. Changed to explicit catch-only deletion.
- Bumped `allowReconnection` from 2.5s → 60s so reconnections have any chance against Render's free-tier cold starts (~30–60s).
- Reconnect failures are now logged instead of silently caught.

### Graceful shutdown
- `onBeforeShutdown` broadcasts a `shutdown` message and disconnects clients before the process exits, so clients can show a notice instead of a generic disconnect.

### Monitor security
- `/colyseus` (Colyseus monitor) was wide open — anyone could view room state and kick clients.
- Gate behind `express-basic-auth` using env vars: `MONITOR_PASSWORD` (required) and optional `MONITOR_USERNAME` (defaults to `admin`).
- If `MONITOR_PASSWORD` is unset, the route is **not mounted** at all (fail closed). A warning is logged.

### Misc
- Replaced deprecated `this.setState(...)` with direct `this.state = ...` assignment.
- Awaited `lock()`/`unlock()`/`disconnect()` since they return promises in 0.17.

## Required Render env var

Set `MONITOR_PASSWORD` in the Render dashboard (Environment) before merging if you want the monitor accessible. Otherwise it's silently disabled, which is fine.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` passes
- [x] `bun run start` boots locally
- [ ] After deploy: existing client at numlingo.vercel.app can still join, play, end, and re-join a fresh round
- [ ] After deploy: `/colyseus` returns 401 when MONITOR_PASSWORD is set, or 404 when it isn't