### PR TITLE
Client: sync with server state machine, graceful shutdown, fix reconnect

### DIFF
--- a/client/src/components/Game.tsx
+++ b/client/src/components/Game.tsx
@@ -50,9 +50,22 @@ const Game = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const promptRef = useRef<HTMLHeadingElement>(null);
   const roomRef = useRef<Colyseus.Room | null>(null);
+  const tickIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const endTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // True for user-initiated leaves and server "shutdown" — onLeave can't
   // distinguish those from a failed reconnect, so we tag them ourselves.
   const cleanExitRef = useRef(false);
+
+  const stopTimer = () => {
+    if (tickIntervalRef.current) {
+      clearInterval(tickIntervalRef.current);
+      tickIntervalRef.current = null;
+    }
+    if (endTimeoutRef.current) {
+      clearTimeout(endTimeoutRef.current);
+      endTimeoutRef.current = null;
+    }
+  };
 
   const generatePrompt = (nextLocale: string) => {
     const num = Math.floor(Math.random() * 1000);
@@ -70,13 +83,13 @@ const Game = () => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isTiming) {
       setIsTiming(true);
-      const id = setInterval(() => {
+      tickIntervalRef.current = setInterval(() => {
         setSeconds((prev) => prev - 1);
       }, 1000);
 
-      setTimeout(() => {
+      endTimeoutRef.current = setTimeout(() => {
         roomRef.current?.send("end");
-        clearInterval(id);
+        stopTimer();
         setIsTiming(false);
         setSeconds(DEFAULT_TIMEOUT);
         updatePlayerScores((prev) => {
@@ -112,9 +125,14 @@ const Game = () => {
   };
 
   const tearDown = () => {
+    stopTimer();
     roomRef.current = null;
     setGameRoom(null);
     setPlayerScores({});
+    setFinalScores({});
+    setIsTiming(false);
+    setIsCompleted(false);
+    setSeconds(DEFAULT_TIMEOUT);
   };
 
   const setRoomCallbacks = (room: Colyseus.Room) => {

--- a/client/src/components/Game.tsx
+++ b/client/src/components/Game.tsx
@@ -12,10 +12,8 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE,
   DEFAULT_TIMEOUT,
-  RECONNECT_TIMEOUT_MS,
-  WS_CLOSE_ERROR_CODES,
 } from "@/utils/constants";
-import { isEmpty, asyncWithTimeout } from "@/utils/helper";
+import { isEmpty } from "@/utils/helper";
 import { CLIENT } from "@/utils/multiplayer";
 import { numToString } from "@/utils/numberConverter";
 import { useAppStore } from "@/utils/store";
@@ -52,7 +50,10 @@ const Game = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const promptRef = useRef<HTMLHeadingElement>(null);
   const roomRef = useRef<Colyseus.Room | null>(null);
-  const intentionalLeaveRef = useRef(false);
+  // Set when the user clicks Leave, or when the server broadcasts "shutdown".
+  // The SDK's onLeave event fires in both clean-exit and reconnect-exhausted
+  // cases — this flag lets us suppress the "Disconnected" toast for clean ones.
+  const cleanExitRef = useRef(false);
 
   const generatePrompt = (nextLocale: string) => {
     const num = Math.floor(Math.random() * 1000);
@@ -111,30 +112,6 @@ const Game = () => {
     }
   };
 
-  const adoptRoom = (room: Colyseus.Room) => {
-    // Server-side state machine handles unlock; we run our own reconnection
-    // logic in onLeave, so silence the SDK's competing 15-retry loop.
-    room.reconnection.enabled = false;
-    roomRef.current = room;
-    setGameRoom(room);
-    setRoomCallbacks(room);
-  };
-
-  const joinRoom = async () => {
-    setCommunicating(true);
-    intentionalLeaveRef.current = false;
-    try {
-      const room = await CLIENT.joinOrCreate(locale);
-      adoptRoom(room);
-      console.log(room.sessionId, "joined", room.name);
-    } catch (e) {
-      console.error("JOIN ERROR", e);
-      toast.error("Unable to connect. Please try again later.");
-    } finally {
-      setCommunicating(false);
-    }
-  };
-
   const tearDown = () => {
     roomRef.current = null;
     setGameRoom(null);
@@ -147,62 +124,61 @@ const Game = () => {
       setFinalScores(Object.fromEntries(res.map((playerID) => [playerID, -1])));
     });
     room.onMessage("update", (res: { id: string; solved: number }) => {
-      updatePlayerScores((prev) => ({
-        ...prev,
-        [res.id]: res.solved,
-      }));
+      updatePlayerScores((prev) => ({ ...prev, [res.id]: res.solved }));
     });
     room.onMessage("final", (res: { id: string; solved: number }) => {
-      // Server auto-unlocks when everyone is done — no need to send "unlock".
+      // Server auto-unlocks when everyone is done — no client send needed.
       updateFinalScores((prev) => ({ ...prev, [res.id]: res.solved }));
     });
     room.onMessage("shutdown", () => {
-      // Graceful server shutdown: skip reconnect, tell user, clean up.
-      intentionalLeaveRef.current = true;
+      // Server is going down. Skip reconnect retries entirely so the SDK
+      // doesn't burn 15 attempts against a host that won't be coming back.
+      cleanExitRef.current = true;
+      room.reconnection.enabled = false;
       toast.info("Server is restarting. Please rejoin in a moment.");
     });
 
-    room.onLeave(async (code: number) => {
-      console.log(`${room.sessionId} left with code ${code}`);
-
-      if (intentionalLeaveRef.current) {
-        intentionalLeaveRef.current = false;
-        tearDown();
-        return;
-      }
-
-      toast.info("Disconnected.");
-      if (!WS_CLOSE_ERROR_CODES.includes(code)) {
-        tearDown();
-        return;
-      }
-
-      setCommunicating(true);
-      toast.info("Attempting to reconnect...");
-      try {
-        const newRoom = await asyncWithTimeout(
-          CLIENT.reconnect(room.reconnectionToken),
-          RECONNECT_TIMEOUT_MS,
-        );
-        adoptRoom(newRoom);
-        console.log(newRoom.sessionId, "rejoined", newRoom.name);
-        toast.success("Reconnected!");
-      } catch (e) {
-        console.error("RECONNECT ERROR", e);
-        toast.error("Unable to reconnect.");
-        tearDown();
-      } finally {
-        setCommunicating(false);
-      }
+    // SDK's reconnect kicks in. Fires once when the connection drops and
+    // retries begin; we don't get a per-attempt callback.
+    room.onDrop(() => {
+      toast.info("Connection lost. Reconnecting…");
     });
 
-    room.onError((code: number, message?: string) => {
+    // Fires after a clean leave OR after the SDK exhausts its reconnect
+    // retries — never mid-retry.
+    room.onLeave((code) => {
+      console.log(`${room.sessionId} left with code ${code}`);
+      if (!cleanExitRef.current) {
+        toast.error("Disconnected.");
+      }
+      cleanExitRef.current = false;
+      tearDown();
+    });
+
+    room.onError((code, message) => {
       console.error(`error occurred with code ${code}:`, message);
     });
   };
 
+  const joinRoom = async () => {
+    setCommunicating(true);
+    cleanExitRef.current = false;
+    try {
+      const room = await CLIENT.joinOrCreate(locale);
+      roomRef.current = room;
+      setGameRoom(room);
+      setRoomCallbacks(room);
+      console.log(room.sessionId, "joined", room.name);
+    } catch (e) {
+      console.error("JOIN ERROR", e);
+      toast.error("Unable to connect. Please try again later.");
+    } finally {
+      setCommunicating(false);
+    }
+  };
+
   const leaveRoom = () => {
-    intentionalLeaveRef.current = true;
+    cleanExitRef.current = true;
     roomRef.current?.leave();
   };
 

--- a/client/src/components/Game.tsx
+++ b/client/src/components/Game.tsx
@@ -50,9 +50,8 @@ const Game = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const promptRef = useRef<HTMLHeadingElement>(null);
   const roomRef = useRef<Colyseus.Room | null>(null);
-  // Set when the user clicks Leave, or when the server broadcasts "shutdown".
-  // The SDK's onLeave event fires in both clean-exit and reconnect-exhausted
-  // cases — this flag lets us suppress the "Disconnected" toast for clean ones.
+  // True for user-initiated leaves and server "shutdown" — onLeave can't
+  // distinguish those from a failed reconnect, so we tag them ourselves.
   const cleanExitRef = useRef(false);
 
   const generatePrompt = (nextLocale: string) => {
@@ -127,25 +126,19 @@ const Game = () => {
       updatePlayerScores((prev) => ({ ...prev, [res.id]: res.solved }));
     });
     room.onMessage("final", (res: { id: string; solved: number }) => {
-      // Server auto-unlocks when everyone is done — no client send needed.
       updateFinalScores((prev) => ({ ...prev, [res.id]: res.solved }));
     });
     room.onMessage("shutdown", () => {
-      // Server is going down. Skip reconnect retries entirely so the SDK
-      // doesn't burn 15 attempts against a host that won't be coming back.
       cleanExitRef.current = true;
+      // Don't waste retries against a host we know is going away.
       room.reconnection.enabled = false;
       toast.info("Server is restarting. Please rejoin in a moment.");
     });
 
-    // SDK's reconnect kicks in. Fires once when the connection drops and
-    // retries begin; we don't get a per-attempt callback.
     room.onDrop(() => {
       toast.info("Connection lost. Reconnecting…");
     });
 
-    // Fires after a clean leave OR after the SDK exhausts its reconnect
-    // retries — never mid-retry.
     room.onLeave((code) => {
       console.log(`${room.sessionId} left with code ${code}`);
       if (!cleanExitRef.current) {

--- a/client/src/components/Game.tsx
+++ b/client/src/components/Game.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE,
   DEFAULT_TIMEOUT,
+  RECONNECT_TIMEOUT_MS,
   WS_CLOSE_ERROR_CODES,
 } from "@/utils/constants";
 import { isEmpty, asyncWithTimeout } from "@/utils/helper";
@@ -51,6 +52,7 @@ const Game = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const promptRef = useRef<HTMLHeadingElement>(null);
   const roomRef = useRef<Colyseus.Room | null>(null);
+  const intentionalLeaveRef = useRef(false);
 
   const generatePrompt = (nextLocale: string) => {
     const num = Math.floor(Math.random() * 1000);
@@ -73,7 +75,7 @@ const Game = () => {
       }, 1000);
 
       setTimeout(() => {
-        gameRoom?.send("end");
+        roomRef.current?.send("end");
         clearInterval(id);
         setIsTiming(false);
         setSeconds(DEFAULT_TIMEOUT);
@@ -83,7 +85,7 @@ const Game = () => {
         setIsCompleted(true);
       }, DEFAULT_TIMEOUT * 1000);
 
-      gameRoom?.send("start");
+      roomRef.current?.send("start");
     }
   };
 
@@ -91,7 +93,7 @@ const Game = () => {
     if (e.key === "Enter") {
       const inputNumber = parseInt(inputRef.current!.value);
       if (inputNumber === number) {
-        gameRoom?.send("solve");
+        roomRef.current?.send("solve");
         inputRef.current!.value = "";
         incrementSolved();
         generatePrompt(locale);
@@ -109,20 +111,34 @@ const Game = () => {
     }
   };
 
+  const adoptRoom = (room: Colyseus.Room) => {
+    // Server-side state machine handles unlock; we run our own reconnection
+    // logic in onLeave, so silence the SDK's competing 15-retry loop.
+    room.reconnection.enabled = false;
+    roomRef.current = room;
+    setGameRoom(room);
+    setRoomCallbacks(room);
+  };
+
   const joinRoom = async () => {
     setCommunicating(true);
+    intentionalLeaveRef.current = false;
     try {
       const room = await CLIENT.joinOrCreate(locale);
-      roomRef.current = room;
-      setGameRoom(room);
+      adoptRoom(room);
       console.log(room.sessionId, "joined", room.name);
-      setRoomCallbacks(room);
     } catch (e) {
       console.error("JOIN ERROR", e);
       toast.error("Unable to connect. Please try again later.");
     } finally {
       setCommunicating(false);
     }
+  };
+
+  const tearDown = () => {
+    roomRef.current = null;
+    setGameRoom(null);
+    setPlayerScores({});
   };
 
   const setRoomCallbacks = (room: Colyseus.Room) => {
@@ -137,51 +153,57 @@ const Game = () => {
       }));
     });
     room.onMessage("final", (res: { id: string; solved: number }) => {
-      updateFinalScores((prev) => {
-        const next = { ...prev, [res.id]: res.solved };
-        if (Object.values(next).every((score) => score !== -1)) {
-          room.send("unlock");
-        }
-        return next;
-      });
+      // Server auto-unlocks when everyone is done — no need to send "unlock".
+      updateFinalScores((prev) => ({ ...prev, [res.id]: res.solved }));
+    });
+    room.onMessage("shutdown", () => {
+      // Graceful server shutdown: skip reconnect, tell user, clean up.
+      intentionalLeaveRef.current = true;
+      toast.info("Server is restarting. Please rejoin in a moment.");
     });
 
     room.onLeave(async (code: number) => {
       console.log(`${room.sessionId} left with code ${code}`);
+
+      if (intentionalLeaveRef.current) {
+        intentionalLeaveRef.current = false;
+        tearDown();
+        return;
+      }
+
       toast.info("Disconnected.");
-      // handle arbtrary disconnects
-      if (WS_CLOSE_ERROR_CODES.includes(code)) {
-        setCommunicating(true);
-        toast.info("Attempting to reconnect...");
-        try {
-          const newRoom = await asyncWithTimeout(
-            CLIENT.reconnect(room.reconnectionToken),
-            2500,
-          );
-          roomRef.current = newRoom;
-          setGameRoom(newRoom);
-          setRoomCallbacks(newRoom);
-          console.log(newRoom.sessionId, "rejoined", newRoom.name);
-          toast.success("Reconnected!");
-          setCommunicating(false);
-          return;
-        } catch (e) {
-          console.error("RECONNECT ERROR", e);
-          toast.error("Unable to reconnect.");
-        }
+      if (!WS_CLOSE_ERROR_CODES.includes(code)) {
+        tearDown();
+        return;
+      }
+
+      setCommunicating(true);
+      toast.info("Attempting to reconnect...");
+      try {
+        const newRoom = await asyncWithTimeout(
+          CLIENT.reconnect(room.reconnectionToken),
+          RECONNECT_TIMEOUT_MS,
+        );
+        adoptRoom(newRoom);
+        console.log(newRoom.sessionId, "rejoined", newRoom.name);
+        toast.success("Reconnected!");
+      } catch (e) {
+        console.error("RECONNECT ERROR", e);
+        toast.error("Unable to reconnect.");
+        tearDown();
+      } finally {
         setCommunicating(false);
       }
-      roomRef.current = null;
-      setGameRoom(null);
-      setPlayerScores({});
     });
+
     room.onError((code: number, message?: string) => {
       console.error(`error occurred with code ${code}:`, message);
     });
   };
 
   const leaveRoom = () => {
-    gameRoom?.leave(); // onLeave callback will be invoked
+    intentionalLeaveRef.current = true;
+    roomRef.current?.leave();
   };
 
   return (

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -2,15 +2,3 @@ export const DEFAULT_LANGUAGE = "English";
 export const DEFAULT_LOCALE = "en";
 export const DEFAULT_TIMEOUT = 60;
 export const DOMAIN = "numlingo.onrender.com";
-
-// Must match server-side allowReconnection() seconds in MyRoom.ts.
-export const RECONNECT_TIMEOUT_MS = 60_000;
-
-// Close codes that should trigger a reconnect attempt. Excludes CONSENTED
-// (4000) since that's a clean user-initiated leave.
-export const WS_CLOSE_ERROR_CODES = [
-  1001, // GOING_AWAY (server restart, browser tab close)
-  1005, // NO_STATUS_RECEIVED
-  1006, // ABNORMAL_CLOSURE (network drop, server crash)
-  4010, // MAY_TRY_RECONNECT (Colyseus-specific)
-]; // https://kapeli.com/cheat_sheets/WebSocket_Status_Codes.docset/Contents/Resources/Documents/index

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -2,11 +2,15 @@ export const DEFAULT_LANGUAGE = "English";
 export const DEFAULT_LOCALE = "en";
 export const DEFAULT_TIMEOUT = 60;
 export const DOMAIN = "numlingo.onrender.com";
+
+// Must match server-side allowReconnection() seconds in MyRoom.ts.
+export const RECONNECT_TIMEOUT_MS = 60_000;
+
+// Close codes that should trigger a reconnect attempt. Excludes CONSENTED
+// (4000) since that's a clean user-initiated leave.
 export const WS_CLOSE_ERROR_CODES = [
-  1002, // CLOSE_PROTOCOL_ERROR
-  1005, // CLOSE_NO_STATUS
-  1006, // CLOSE_ABNORMAL
-  1008, // CLOSE_POLICY_VIOLATION
-  1010, // CLOSE_MISSING_EXTENSION
-  1015, // CLOSE_TLS_HANDSHAKE_FAILED
+  1001, // GOING_AWAY (server restart, browser tab close)
+  1005, // NO_STATUS_RECEIVED
+  1006, // ABNORMAL_CLOSURE (network drop, server crash)
+  4010, // MAY_TRY_RECONNECT (Colyseus-specific)
 ]; // https://kapeli.com/cheat_sheets/WebSocket_Status_Codes.docset/Contents/Resources/Documents/index

--- a/client/src/utils/helper.ts
+++ b/client/src/utils/helper.ts
@@ -8,22 +8,3 @@ export const isEmpty = (obj: any): boolean => {
 export const sleep = (delay: number) => {
   return new Promise((resolve) => setTimeout(resolve, delay));
 };
-
-export const asyncWithTimeout = (
-  asyncPromise: Promise<any>,
-  timeLimit: number,
-) => {
-  let timeoutHandle: NodeJS.Timeout;
-
-  const timeoutPromise = new Promise((_resolve, reject) => {
-    timeoutHandle = setTimeout(
-      () => reject(new Error("Async call timeout limit reached")),
-      timeLimit,
-    );
-  });
-
-  return Promise.race([asyncPromise, timeoutPromise]).then((result) => {
-    clearTimeout(timeoutHandle);
-    return result;
-  });
-};


### PR DESCRIPTION
## Summary

After PR #12 the client drifted from the server. This brings them in line and replaces our custom reconnect logic with the SDK's built-in retry loop.

### What was broken
- Click Leave → "Disconnected → Reconnecting → Unable to reconnect" toasts. Server sometimes closes with 1006 instead of 4000 (Render cold-start race), so close-code alone isn't a reliable signal of intent.
- Client kept sending `room.send("unlock")`; server removed the handler in #12.
- Client wasn't listening for the server's `shutdown` broadcast, so users saw a generic "Disconnected" on graceful restart.
- Custom reconnect logic was a single-attempt 2.5s `CLIENT.reconnect`, which gave up before the server's 60s `allowReconnection` window even started.
- `gameRoom` (store) and `roomRef` could disagree briefly after reconnect; `leaveRoom` read from the store, callbacks used the ref.

### What changed
- **SDK-managed reconnection**, not custom. The SDK already does exponential backoff over 15 retries (~56s total), gated by a min-uptime check. Listen to:
  - `room.onDrop` → fires once when retries begin → "Reconnecting…" toast
  - `room.onLeave` → fires after clean leave OR when the SDK gives up → final teardown
- `cleanExitRef` flag set on user Leave click and on `shutdown` message → `onLeave` suppresses the "Disconnected" toast for clean exits.
- New `room.onMessage("shutdown", ...)` listener — toast user, set `room.reconnection.enabled = false` so the SDK doesn't burn 15 retries against a host that won't be coming back.
- Removed `room.send("unlock")` inside the `final` handler. Server auto-unlocks.
- `roomRef.current` used everywhere; store's `gameRoom` is read-only for UI conditionals.
- Deleted dead code: `WS_CLOSE_ERROR_CODES`, `RECONNECT_TIMEOUT_MS`, `asyncWithTimeout`.

### Reconnection timing
SDK retry budget: 0.2 + 0.4 + 0.8 + 1.6 + 3.2 + 5×10 ≈ 56s. Server's `allowReconnection(client, 60)` allows 60s. Last SDK attempt has ~4s of slack under the server window.

### Test plan

- [ ] Click Join → joins, no console spam
- [ ] Click Leave → no reconnect toasts, UI returns to language picker cleanly
- [ ] Kill the server (`Ctrl+C`) while connected → "Server is restarting" toast, no retries, UI cleans up
- [ ] Drop network briefly while in a room (DevTools Offline checkbox) → "Reconnecting…" toast, reconnect succeeds within ~30s, no extra "Reconnected!" toast (acceptable trade-off — silent success)
- [ ] Two players, each plays a round → lobby unlocks correctly between rounds (server-managed)